### PR TITLE
Added support for Enums to diff like primatives

### DIFF
--- a/ObjectDiffer.Test/DifferTests.cs
+++ b/ObjectDiffer.Test/DifferTests.cs
@@ -40,7 +40,7 @@ namespace ObjectDiffer.Test
                 return Id;
             }
         }
-
+        private enum TestEnum { A,B}
         [Test]
         public void PropertyDifferenceIndexerShouldReturnChildDiffWithMatchingPropertyName()
         {
@@ -393,6 +393,13 @@ namespace ObjectDiffer.Test
 
             Assert.AreEqual(dt1, diff.NewValue);
             Assert.AreEqual(dt2, diff.OldValue);
+        }
+
+        [Test]
+        public void ShouldDiffEnumsCorrectly()
+        {
+            Assert.IsNull(_differ.Diff(TestEnum.A, TestEnum.A));
+            Assert.IsNotNull(_differ.Diff(TestEnum.A, TestEnum.B));
         }
     }
 

--- a/ObjectDiffer/TypeDiffers/PrimativeDiffer.cs
+++ b/ObjectDiffer/TypeDiffers/PrimativeDiffer.cs
@@ -8,6 +8,7 @@ namespace ObjectDiffer.TypeDiffers
         public bool CanPerformDiff(Type t)
         {
             return t.IsPrimitive 
+                || t.IsEnum
                 || t == typeof(DateTime); // treat DateTime's as primatives, because the "Date" property has a circular reference to itself, which causes a stack overflow
         }
 


### PR DESCRIPTION
I noticed that Enums were not being treated like primitives and so the diff was not working correctly. I've added a simple check in the PrimativeDiffer.